### PR TITLE
New MOD Instruction for RISCV

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -4921,6 +4921,17 @@ decode QUADRANT default Unknown::unknown() {
             }}, IsIndirectControl, IsUncondControl);
         }
 
+        //CUSTOM INSTRUCTION Modulus
+        0x1a: decode FUNCT3 {
+            format ROp {
+                0x0: decode FUNCT7 {
+                    0x01: mod({{
+                        Rd = Rs1_sd % Rs2_sd;
+                        }});
+                    }
+                }
+            }
+        //END of custom instruction
         0x1b: JOp::jal({{
             Rd = rvSext(NPC);
             NPC = rvSext(PC + imm);


### PR DESCRIPTION
- Followed Nick Felker's tutorial/medium article on how to extend gem5 with custom RISC-V commands: https://fleker.medium.com/extending-gem5-with-custom-risc-v-commands-653eeefe83b8
- Developed a binary using the risc-v toolchain with the instrutction explictly included and pointed a configuration file (in this case a riscv version of `simple.py`)
- Added the custom instruction to `src/arch/riscv/isa/decoder.isa` 
- ***WARNING*** The parser that uses this file is case sensitive so be sure to use common letters for hex values.
- Rebuild gem5 and ensure the built RISCV gem5 included the instruction in `build/RISCV/arch/riscv/generated/decode-method.cc.inc`
- Custom instruction verified once configuration file was executed within gem5.